### PR TITLE
feat(search): implement pagination for search results (discover page)

### DIFF
--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -8,33 +8,81 @@ import {
 } from "@/components/places";
 import { useSearch } from "@/hooks/useSearch";
 import { SearchSkeleton } from "./SearchSkeleton";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertCircle } from "lucide-react";
+import { PlaceCardSkeleton } from "@/components/skeletons/PlaceCardSkeleton";
 
 export const SearchResults = () => {
-  const { data, isPending } = useSearch();
+  const {
+    data,
+    isPending,
+    loadMore,
+    hasMore,
+    isLoadingMore,
+    paginationError,
+    size,
+  } = useSearch();
 
-  if (isPending) {
+  const skeletonCount = size || 3;
+
+  if (isPending && !data?.places?.length) {
     return <SearchSkeleton />;
   }
 
-  if (!data?.places.length) {
+  if (!data?.places?.length) {
     return <NoPlaceResults />;
   }
 
   return (
-    <ul className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-      {data.places.map((place) => (
-        <PlaceCard
-          isListItem
-          key={place.id}
-          place={place}
-          actions={
-            <>
-              <LikeButton placeId={place.id} />
-              <SaveToListButton placeId={place.id} />
-            </>
-          }
-        />
-      ))}
-    </ul>
+    <div className="space-y-8">
+      <ul className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {data?.places?.map((place) => (
+          <PlaceCard
+            isListItem
+            key={place.id}
+            place={place}
+            actions={
+              <>
+                <LikeButton placeId={place.id} />
+                <SaveToListButton placeId={place.id} />
+              </>
+            }
+          />
+        ))}
+      </ul>
+
+      {isLoadingMore && (
+        <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {[...Array(skeletonCount)].map((_, i) => (
+            <PlaceCardSkeleton
+              key={`loading-skeleton-${i}`}
+              showActions={true}
+            />
+          ))}
+        </div>
+      )}
+
+      {paginationError && (
+        <Alert variant="destructive" className="mt-4">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>{paginationError}</AlertDescription>
+        </Alert>
+      )}
+
+      {hasMore && (
+        <div className="flex justify-center">
+          <Button
+            onClick={loadMore}
+            disabled={isLoadingMore}
+            variant="outline"
+            size="lg"
+            className="min-w-32"
+          >
+            {isLoadingMore ? "Loading..." : "Load More"}
+          </Button>
+        </div>
+      )}
+    </div>
   );
 };

--- a/src/components/search/SearchSkeleton.tsx
+++ b/src/components/search/SearchSkeleton.tsx
@@ -1,9 +1,13 @@
 import { PlaceCardSkeleton } from "../skeletons/PlaceCardSkeleton";
 
-export const SearchSkeleton = () => {
+interface SearchSkeletonProps {
+  count?: number;
+}
+
+export const SearchSkeleton = ({ count = 12 }: SearchSkeletonProps) => {
   return (
     <div className="mt-8 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-      {Array.from({ length: 12 }).map((_, i) => (
+      {Array.from({ length: count }).map((_, i) => (
         <PlaceCardSkeleton key={i} showActions />
       ))}
     </div>

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertTitle, AlertDescription }

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -4,6 +4,7 @@ export const QUERY_KEYS = {
   PROFILE: "profile",
   USER_LISTS: "userLists",
   SEARCH: "search",
+  SEARCH_MORE: "search-more",
   LIKES: "likes",
   PLACE_LISTS: "placeLists",
   LIKES_STATUSES: "likesStatuses",

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -3,6 +3,8 @@ import { PLACE_FILTERS, QUERY_KEYS } from "@/constants";
 import { searchPlacesClient } from "@/lib/search";
 import { useLocation } from "@/contexts/LocationContext";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { Place } from "@/types";
 
 export interface SearchFilters {
   minRating?: number;
@@ -24,6 +26,7 @@ export const useSearch = () => {
   const router = useRouter();
   const pathname = usePathname();
 
+  // Extract search parameters from URL
   const query = searchParams.get("q") ?? "";
   const minRating = searchParams.get("rating")
     ? Number(searchParams.get("rating"))
@@ -36,73 +39,265 @@ export const useSearch = () => {
     ? Number(searchParams.get("size"))
     : defaultSize;
 
-  const filters = {
-    minRating,
-    openNow,
-    radius,
-  };
+  const [allPlaces, setAllPlaces] = useState<Place[]>([]);
+  const [pageToken, setPageToken] = useState<string | null>(null);
+  const [paginationError, setPaginationError] = useState<string | null>(null);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [currentQuery, setCurrentQuery] = useState<string>(query);
+  const isChangingSearchParams = useRef(false);
 
-  const updateSearchParams = ({
-    query,
-    filters,
-    size,
-  }: UpdateSearchParamsProps) => {
-    const params = new URLSearchParams(searchParams);
+  const filters = useMemo(
+    () => ({
+      minRating,
+      openNow,
+      radius,
+    }),
+    [minRating, openNow, radius],
+  );
 
-    if (query) {
-      params.set("q", query);
-    } else {
-      params.delete("q");
+  useEffect(() => {
+    isChangingSearchParams.current = true;
+
+    setCurrentQuery(query);
+
+    setPageToken(null);
+    setAllPlaces([]);
+    setPaginationError(null);
+
+    const timeoutId = setTimeout(() => {
+      isChangingSearchParams.current = false;
+    }, 50);
+
+    return () => clearTimeout(timeoutId);
+  }, [query, minRating, openNow, radius, size]);
+
+  const updateSearchParams = useCallback(
+    ({ query, filters, size }: UpdateSearchParamsProps) => {
+      const params = new URLSearchParams(searchParams);
+
+      if (query) {
+        params.set("q", query);
+      } else {
+        params.delete("q");
+      }
+
+      if (
+        filters?.radius !== undefined &&
+        filters.radius !== PLACE_FILTERS.RADIUS.DEFAULT
+      ) {
+        params.set("radius", filters.radius.toString());
+      } else {
+        params.delete("radius");
+      }
+
+      if (
+        filters?.minRating &&
+        filters.minRating !== PLACE_FILTERS.RATING.MIN
+      ) {
+        params.set("rating", filters.minRating.toString());
+      } else {
+        params.delete("rating");
+      }
+
+      if (filters?.openNow) {
+        params.set("open", "true");
+      } else {
+        params.delete("open");
+      }
+
+      if (size && size !== defaultSize) {
+        params.set("size", size.toString());
+      } else {
+        params.delete("size");
+      }
+
+      const newParamsString = params.toString();
+      const oldParamsString = searchParams.toString();
+
+      if (newParamsString === oldParamsString) {
+        return;
+      }
+
+      const targetPath = pathname === "/" ? "/discover" : pathname;
+      router.push(`${targetPath}?${newParamsString}`, { scroll: false });
+    },
+    [searchParams, router, pathname],
+  );
+
+  const {
+    data: searchData,
+    isPending,
+    isError,
+  } = useQuery({
+    queryKey: [QUERY_KEYS.SEARCH, query, filters, size, coords],
+    queryFn: async () => {
+      try {
+        const result = await searchPlacesClient(
+          query,
+          size,
+          coords,
+          filters,
+          undefined,
+        );
+
+        if (!result) {
+          throw new Error("No search results found");
+        }
+
+        return result;
+      } catch (error) {
+        console.error("Search error:", error);
+        throw error;
+      }
+    },
+    enabled: !isLoadingLocation && query.length > 0,
+    staleTime: 1000 * 60 * 5, // 5 minutes
+    refetchOnWindowFocus: false,
+  });
+
+  const { data: paginationData, isPending: isPaginationPending } = useQuery({
+    queryKey: [QUERY_KEYS.SEARCH_MORE, query, filters, size, coords, pageToken],
+    queryFn: async ({ queryKey }) => {
+      const queryFromKey = queryKey[1] as string;
+      const tokenFromKey = queryKey[5] as string | null;
+
+      if (isChangingSearchParams.current) {
+        console.warn(
+          "Search parameters are changing, aborting pagination request",
+        );
+        return null;
+      }
+
+      if (!tokenFromKey) {
+        return null;
+      }
+
+      if (queryFromKey !== currentQuery) {
+        console.warn("Query has changed, aborting pagination request");
+        return null;
+      }
+
+      try {
+        const result = await searchPlacesClient(
+          queryFromKey,
+          size,
+          coords,
+          filters,
+          tokenFromKey,
+        );
+
+        if (!result) {
+          throw new Error("Failed to load more results");
+        }
+
+        return result;
+      } catch (error) {
+        console.error("Pagination error:", error);
+        setPaginationError("Failed to load more results. Please try again.");
+        throw error;
+      } finally {
+        setIsLoadingMore(false);
+      }
+    },
+    enabled:
+      !!pageToken &&
+      query.length > 0 &&
+      query === currentQuery &&
+      !isChangingSearchParams.current,
+    staleTime: 1000 * 60 * 5, // 5 minutes
+    refetchOnWindowFocus: false,
+  });
+
+  useEffect(() => {
+    if (searchData?.places && allPlaces.length === 0) {
+      setAllPlaces(searchData.places);
+    }
+  }, [searchData, allPlaces.length]);
+
+  useEffect(() => {
+    if (paginationData?.places && pageToken) {
+      setAllPlaces((prevPlaces) => {
+        const existingIds = new Map(
+          prevPlaces.map((place) => [place.id, true]),
+        );
+
+        const newPlaces = paginationData.places.filter(
+          (place) => !existingIds.has(place.id),
+        );
+
+        return [...prevPlaces, ...newPlaces];
+      });
+    }
+  }, [paginationData, pageToken]);
+
+  const loadMore = useCallback(
+    async (e?: React.MouseEvent) => {
+      if (e) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+
+      if (isChangingSearchParams.current) {
+        console.warn("Search parameters are changing, not loading more");
+        return;
+      }
+
+      if (query !== currentQuery) {
+        console.warn("Query has changed, not loading more");
+        return;
+      }
+
+      const nextPageToken = pageToken
+        ? paginationData?.nextPageToken
+        : searchData?.nextPageToken;
+
+      if (!nextPageToken) {
+        return;
+      }
+
+      try {
+        setPaginationError(null);
+        setIsLoadingMore(true);
+        setPageToken(nextPageToken);
+      } catch (error) {
+        console.error("Error loading more results:", error);
+        setPaginationError("Failed to load more results. Please try again.");
+        setIsLoadingMore(false);
+      }
+    },
+    [
+      searchData?.nextPageToken,
+      paginationData?.nextPageToken,
+      pageToken,
+      query,
+      currentQuery,
+    ],
+  );
+
+  const mergedData = useMemo(() => {
+    if (!searchData && allPlaces.length === 0) {
+      return undefined;
     }
 
-    if (
-      filters?.radius !== undefined &&
-      filters.radius !== PLACE_FILTERS.RADIUS.DEFAULT
-    ) {
-      params.set("radius", filters.radius.toString());
-    } else {
-      params.delete("radius");
-    }
-
-    if (filters?.minRating && filters.minRating !== PLACE_FILTERS.RATING.MIN) {
-      params.set("rating", filters.minRating.toString());
-    } else {
-      params.delete("rating");
-    }
-
-    if (filters?.openNow) {
-      params.set("open", "true");
-    } else {
-      params.delete("open");
-    }
-
-    if (size && size !== defaultSize) {
-      params.set("size", size.toString());
-    } else {
-      params.delete("size");
-    }
-
-    const newParamsString = params.toString();
-    const oldParamsString = searchParams.toString();
-
-    if (newParamsString === oldParamsString) {
-      return;
-    }
-
-    const targetPath = pathname === "/" ? "/discover" : pathname;
-    router.push(`${targetPath}?${newParamsString}`, { scroll: false });
-  };
+    return {
+      ...(paginationData || searchData),
+      places: allPlaces,
+    };
+  }, [searchData, paginationData, allPlaces]);
 
   return {
     query,
     filters,
     size,
     updateSearchParams,
-    ...useQuery({
-      queryKey: [QUERY_KEYS.SEARCH, query, filters, size, coords],
-      queryFn: () => searchPlacesClient(query, size, coords, filters),
-      enabled: !isLoadingLocation && query.length > 0,
-      staleTime: 1000 * 60 * 5,
-    }),
+    data: mergedData,
+    isPending: isPending && !searchData,
+    isError,
+    loadMore,
+    hasMore: !!(pageToken
+      ? paginationData?.nextPageToken
+      : searchData?.nextPageToken),
+    isLoadingMore: isPaginationPending && isLoadingMore,
+    paginationError,
   };
 };

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -114,7 +114,7 @@
 
 @layer base {
   * {
-    @apply border-border;
+    @apply border-border outline-ring/50;
   }
   body {
     @apply bg-background text-foreground;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -148,6 +148,7 @@ export interface PlaceSearchResponse {
   places: Place[];
   likeStatuses: LikeStatuses;
   userLists: DbListWithPlacesCount[];
+  nextPageToken?: string;
 }
 
 export interface ListResponse {


### PR DESCRIPTION
## Description

This PR adds pagination functionality to the search results on the discover page, allowing users to incrementally load more places beyond the initial results.

- Added page token handling in the `useSearch` hook
- Implemented proper state management for accumulated search results
- Added safety mechanisms to prevent API errors from mismatched page tokens
- Created UI components for "Load More" functionality with loading states
- Added error handling for pagination failures