### PR TITLE
refactor: update profile, likes, and lists fetching logic

### DIFF
--- a/src/app/api/users/[username]/lists/route.ts
+++ b/src/app/api/users/[username]/lists/route.ts
@@ -31,12 +31,11 @@ export async function GET(request: Request, { params }: RouteParams) {
     }
 
     const session = await getServerSession();
-    const isOwnProfile =
-      session?.user.username === validatedParams.params.username;
+    const isOwner = session?.user.username === validatedParams.params.username;
 
     const paginatedLists = await lists.queries.getAllByUsername(
       validatedParams.params.username,
-      isOwnProfile,
+      isOwner,
       result.data,
     );
 

--- a/src/components/lists/ListCard/ListCard.tsx
+++ b/src/components/lists/ListCard/ListCard.tsx
@@ -14,7 +14,7 @@ import { cn } from "@/lib/utils";
 
 interface ListCardProps {
   list: DbListWithPlacesCount;
-  isOwnProfile: boolean;
+  isOwner: boolean;
   username: string;
   showPrivacyBadge?: boolean;
   onEdit: (list: DbListWithPlacesCount) => void;
@@ -23,7 +23,7 @@ interface ListCardProps {
 
 export const ListCard = ({
   list,
-  isOwnProfile,
+  isOwner,
   username,
   showPrivacyBadge = false,
   onEdit,
@@ -85,7 +85,7 @@ export const ListCard = ({
               <ListTitle name={list.name} />
             </Link>
 
-            {isOwnProfile && (
+            {isOwner && (
               <ListActions
                 list={list}
                 username={username}

--- a/src/components/lists/ListView.tsx
+++ b/src/components/lists/ListView.tsx
@@ -51,14 +51,14 @@ const PlaceActions = ({ placeId, username }: PlaceActionsProps) => {
 interface ListViewProps {
   list: DbList;
   username: string;
-  isOwnProfile: boolean;
+  isOwner: boolean;
   currentPage: number;
 }
 
 export const ListView = ({
   list,
   username,
-  isOwnProfile,
+  isOwner,
   currentPage,
 }: ListViewProps) => {
   const { data, isLoading, error } = useSavedPlaces(list.id, currentPage);
@@ -155,7 +155,7 @@ export const ListView = ({
               {(data?.metadata.totalItems ?? 0) === 1 ? "place" : "places"}
             </span>
           </div>
-          {isOwnProfile && (
+          {isOwner && (
             <span className="text-sm text-muted-foreground">
               {list.isPublic ? "Public" : "Private"}
             </span>

--- a/src/components/lists/ListsView.tsx
+++ b/src/components/lists/ListsView.tsx
@@ -23,7 +23,7 @@ import { ListCard } from "@/components/lists/ListCard";
 interface ListsViewProps {
   lists: DbListWithPlacesCount[];
   username: string;
-  isOwnProfile: boolean;
+  isOwner: boolean;
   totalPages: number;
   currentPage: number;
   totalLists: number;
@@ -32,7 +32,7 @@ interface ListsViewProps {
 export const ListsView = ({
   lists,
   username,
-  isOwnProfile,
+  isOwner,
   totalPages,
   currentPage,
   totalLists,
@@ -132,7 +132,7 @@ export const ListsView = ({
           <div className="rounded-md border p-2">
             Search/filtering coming soon
           </div>
-          {isOwnProfile && (
+          {isOwner && (
             <Button onClick={() => setIsCreateDialogOpen(true)}>
               <Plus aria-hidden="true" className="mr-2 size-4" />
               New List
@@ -152,8 +152,8 @@ export const ListsView = ({
                 key={list.id}
                 list={list}
                 username={username}
-                isOwnProfile={isOwnProfile}
-                showPrivacyBadge={isOwnProfile}
+                isOwner={isOwner}
+                showPrivacyBadge={isOwner}
                 onEdit={() => setEditingList(list)}
                 onDelete={() => setDeletingList(list)}
               />

--- a/src/components/places/LikeButton.tsx
+++ b/src/components/places/LikeButton.tsx
@@ -23,8 +23,8 @@ export const LikeButton = ({
   const { data: userData, like } = usePlaceInteractions();
   const { toggle: toggleLike, isPending } = like;
   const isInLikesTab = !!username;
-  const isOwnProfile = session?.user.username === username;
-  const shouldUpdateLikesQuery = isInLikesTab && isOwnProfile;
+  const isOwner = session?.user.username === username;
+  const shouldUpdateLikesQuery = isInLikesTab && isOwner;
   const likesQuery = useLikesInfinite(username ?? "", shouldUpdateLikesQuery);
 
   const isLiked = userData?.likes.some((like) => like.placeId === placeId);

--- a/src/components/profile/ProfileHeader.tsx
+++ b/src/components/profile/ProfileHeader.tsx
@@ -15,14 +15,14 @@ import {
 
 interface ProfileHeaderProps {
   user: DbUser;
-  isOwnProfile: boolean;
+  isOwner: boolean;
   totalLists: number;
   totalLikes: number;
 }
 
 export const ProfileHeader = ({
   user,
-  isOwnProfile,
+  isOwner,
   totalLists,
   totalLikes,
 }: ProfileHeaderProps) => {
@@ -56,7 +56,7 @@ export const ProfileHeader = ({
           backgroundColor: user.colour || "hsl(var(--muted))",
         }}
       >
-        {isOwnProfile && (
+        {isOwner && (
           <div className="container mx-auto flex justify-end gap-2 px-4 pt-6 md:max-w-3xl">
             <ProfileActions
               colour={user.colour}

--- a/src/components/profile/ProfileLikesTab.tsx
+++ b/src/components/profile/ProfileLikesTab.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useLikesInfinite } from "@/hooks/useLikes";
+import { LikeItem } from "@/server/types/profile";
+import { useInView } from "react-intersection-observer";
+import { TabsContent } from "../ui/tabs";
+import { PlaceCardSkeleton } from "../skeletons/PlaceCardSkeleton";
+import { PlaceCard } from "../places/PlaceCard";
+import LikeButton from "../places/LikeButton";
+import { SaveToListButton } from "../places";
+
+interface ProfileLikesTabProps {
+  username: string;
+}
+
+export const ProfileLikesTab = ({ username }: ProfileLikesTabProps) => {
+  const {
+    data: likesData,
+    fetchNextPage: fetchNextLikes,
+    hasNextPage: hasNextLikes,
+    isFetchingNextPage: isFetchingNextLikes,
+    status: likesStatus,
+  } = useLikesInfinite(username, true);
+
+  const { ref: likesRef } = useInView({
+    threshold: 0,
+    rootMargin: "200px 0px",
+    onChange: (inView) => {
+      if (inView && hasNextLikes && !isFetchingNextLikes) {
+        fetchNextLikes();
+      }
+    },
+  });
+
+  const allLikes =
+    likesData?.pages.flatMap((page, pageIndex) =>
+      page.items.map((item: LikeItem) => ({
+        ...item,
+        key: `${item.placeId}-${pageIndex}`,
+      })),
+    ) ?? [];
+
+  return (
+    <TabsContent value="likes">
+      {likesStatus === "pending" ? (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <PlaceCardSkeleton showActions key={i} />
+          ))}
+        </div>
+      ) : likesStatus === "error" ? (
+        <div className="py-8 text-center text-red-500">Error loading likes</div>
+      ) : (
+        <div className="space-y-8">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {allLikes.map((like) => (
+              <PlaceCard
+                key={like.key}
+                place={like.place}
+                isListItem
+                actions={
+                  <div className="flex flex-col gap-2">
+                    <LikeButton placeId={like.placeId} username={username} />
+                    <SaveToListButton placeId={like.placeId} />
+                  </div>
+                }
+              />
+            ))}
+          </div>
+
+          <div ref={likesRef}>
+            {hasNextLikes ? (
+              isFetchingNextLikes ? (
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <PlaceCardSkeleton showActions />
+                  <PlaceCardSkeleton showActions />
+                </div>
+              ) : (
+                <div className="flex justify-center py-4">
+                  <span className="text-sm text-muted-foreground">
+                    Scroll for more likes
+                  </span>
+                </div>
+              )
+            ) : null}
+          </div>
+        </div>
+      )}
+    </TabsContent>
+  );
+};

--- a/src/components/profile/ProfileLists.tsx
+++ b/src/components/profile/ProfileLists.tsx
@@ -21,7 +21,7 @@ import ListCreateDialog from "../lists/ListCreateDialog";
 interface ProfileListsProps {
   lists: DbListWithPlacesCount[];
   username: string;
-  isOwnProfile: boolean;
+  isOwner: boolean;
   totalPages: number;
   currentPage: number;
 }
@@ -29,7 +29,7 @@ interface ProfileListsProps {
 export const ProfileLists = ({
   lists,
   username,
-  isOwnProfile,
+  isOwner,
   totalPages,
   currentPage,
 }: ProfileListsProps) => {
@@ -100,8 +100,8 @@ export const ProfileLists = ({
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between">
-        <CardTitle>{isOwnProfile ? "My Lists" : "Their Lists"}</CardTitle>
-        {isOwnProfile && (
+        <CardTitle>{isOwner ? "My Lists" : "Their Lists"}</CardTitle>
+        {isOwner && (
           <Button
             variant="outline"
             size="sm"
@@ -119,8 +119,8 @@ export const ProfileLists = ({
               key={list.id}
               list={list}
               username={username}
-              isOwnProfile={isOwnProfile}
-              showPrivacyBadge={isOwnProfile}
+              isOwner={isOwner}
+              showPrivacyBadge={isOwner}
               onEdit={() => setEditingList(list)}
               onDelete={() => setDeletingList(list)}
             />

--- a/src/components/profile/ProfileListsTab.tsx
+++ b/src/components/profile/ProfileListsTab.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useListsInfinite } from "@/hooks/useLists";
+import { ListCard } from "../lists/ListCard";
+import { ListCardSkeleton } from "../skeletons/ListCardSkeleton";
+import { TabsContent } from "../ui/tabs";
+import { useInView } from "react-intersection-observer";
+import { DbListWithPlacesCount } from "@/server/types/db";
+
+interface ProfileListsTabProps {
+  username: string;
+  isOwner: boolean;
+  onEdit: (list: DbListWithPlacesCount) => void;
+  onDelete: (list: DbListWithPlacesCount) => void;
+}
+
+export const ProfileListsTab = ({
+  username,
+  isOwner,
+  onEdit,
+  onDelete,
+}: ProfileListsTabProps) => {
+  const {
+    data: listsData,
+    fetchNextPage: fetchNextLists,
+    hasNextPage: hasNextLists,
+    isFetchingNextPage: isFetchingNextLists,
+    status: listsStatus,
+  } = useListsInfinite(username);
+
+  const { ref: listsRef } = useInView({
+    threshold: 0,
+    rootMargin: "200px 0px",
+    onChange: (inView) => {
+      if (inView && hasNextLists && !isFetchingNextLists) {
+        fetchNextLists();
+      }
+    },
+  });
+
+  const allLists =
+    listsData?.pages.flatMap((page, pageIndex) =>
+      page.items.map((item) => ({
+        ...item,
+        key: `${item.id}-${pageIndex}`,
+      })),
+    ) ?? [];
+
+  return (
+    <TabsContent value="lists">
+      {listsStatus === "pending" ? (
+        <div className="space-y-8">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <ListCardSkeleton key={i} />
+          ))}
+        </div>
+      ) : listsStatus === "error" ? (
+        <div className="py-8 text-center text-red-500">Error loading lists</div>
+      ) : (
+        <div className="space-y-8">
+          {allLists.map((list) => (
+            <ListCard
+              key={list.key}
+              list={list}
+              username={username}
+              isOwner={isOwner}
+              onEdit={onEdit}
+              onDelete={onDelete}
+              showPrivacyBadge={isOwner}
+            />
+          ))}
+
+          <div ref={listsRef}>
+            {hasNextLists ? (
+              isFetchingNextLists ? (
+                <ListCardSkeleton />
+              ) : (
+                <div className="flex justify-center py-4">
+                  <span className="text-sm text-muted-foreground">
+                    Scroll for more lists
+                  </span>
+                </div>
+              )
+            ) : null}
+          </div>
+        </div>
+      )}
+    </TabsContent>
+  );
+};

--- a/src/constants/likes.ts
+++ b/src/constants/likes.ts
@@ -1,0 +1,9 @@
+export const LIKES_FIELD_MASK = [
+  "id",
+  "displayName",
+  "formattedAddress",
+  "photos",
+  "rating",
+  "userRatingCount",
+  "priceLevel",
+].join(",");

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -21,12 +21,11 @@ export const useProfile = ({ username, initialData }: UseProfileOptions) => {
     initialData,
   });
 
-  const isOwnProfile =
-    profile?.type === "public" && session?.user.id === profile.id;
+  const isOwner = profile?.type === "public" && session?.user.id === profile.id;
 
   return {
     profile,
-    isOwnProfile,
+    isOwner,
     isLoading: false,
   };
 };

--- a/src/lib/validations/profile.ts
+++ b/src/lib/validations/profile.ts
@@ -1,10 +1,16 @@
-import { PAGINATION } from "@/constants";
 import { z } from "zod";
+import { PAGINATION } from "@/constants";
 
 export const profileParamsSchema = z.object({
+  username: z.string().min(1).max(50),
+});
+
+export type ProfileParams = z.infer<typeof profileParamsSchema>;
+
+export const profileLikesParamsSchema = z.object({
   username: z.string().min(1).max(50),
   page: z.coerce.number().int().positive().default(1),
   limit: z.coerce.number().int().positive().default(PAGINATION.ITEMS_PER_PAGE),
 });
 
-export type ProfileParams = z.infer<typeof profileParamsSchema>;
+export type ProfileLikesParams = z.infer<typeof profileLikesParamsSchema>;

--- a/src/lib/validations/profile.ts
+++ b/src/lib/validations/profile.ts
@@ -14,3 +14,11 @@ export const profileLikesParamsSchema = z.object({
 });
 
 export type ProfileLikesParams = z.infer<typeof profileLikesParamsSchema>;
+
+export const profileListsParamsSchema = z.object({
+  username: z.string().min(1).max(50),
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().positive().default(PAGINATION.ITEMS_PER_PAGE),
+});
+
+export type ProfileListsParams = z.infer<typeof profileListsParamsSchema>;

--- a/src/server/data/likes.ts
+++ b/src/server/data/likes.ts
@@ -26,7 +26,7 @@ export const likes = {
 
     getAllByUserId: async (
       userId: DbUser["id"],
-      { page = 1, limit = 10 }: PaginationParams,
+      { page = 1, limit = 10 }: PaginationParams = {},
     ): Promise<PaginatedResponse<DbLike>> => {
       return unstable_cache(
         async () => {
@@ -100,7 +100,7 @@ export const likes = {
 
     getPaginatedLikes: async (
       userId: DbUser["id"],
-      { page = 1, limit = 10 }: PaginationParams,
+      { page = 1, limit = 10 }: PaginationParams = {},
     ): Promise<PaginatedResponse<DbLike>> => {
       const userLikes = await likes.queries.getAllByUserId(userId, {
         page,

--- a/src/server/data/likes.ts
+++ b/src/server/data/likes.ts
@@ -6,6 +6,16 @@ import type { DbLike, DbUser } from "@/server/types/db";
 import { getServerSession } from "../auth/session";
 import type { PaginationParams } from "@/types";
 
+export type PaginatedLikes = {
+  items: DbLike[];
+  metadata: {
+    currentPage: number;
+    totalPages: number;
+    totalItems: number;
+    hasNextPage: boolean;
+  };
+};
+
 export const likes = {
   queries: {
     getByPlaceId: async (userId: DbUser["id"], placeId: DbLike["placeId"]) => {
@@ -25,8 +35,8 @@ export const likes = {
 
     getAllByUserId: async (
       userId: DbUser["id"],
-      { page = 1, limit = 10 }: PaginationParams = {},
-    ) => {
+      { page = 1, limit = 10 }: PaginationParams,
+    ): Promise<PaginatedLikes> => {
       return unstable_cache(
         async () => {
           const offset = (page - 1) * limit;
@@ -95,6 +105,18 @@ export const likes = {
       );
 
       return cachedFn();
+    },
+
+    getPaginatedLikes: async (
+      userId: DbUser["id"],
+      { page = 1, limit = 10 }: PaginationParams,
+    ): Promise<PaginatedLikes> => {
+      const userLikes = await likes.queries.getAllByUserId(userId, {
+        page,
+        limit,
+      });
+
+      return userLikes;
     },
   },
 

--- a/src/server/data/likes.ts
+++ b/src/server/data/likes.ts
@@ -5,16 +5,7 @@ import { like } from "@/server/db/schema";
 import type { DbLike, DbUser } from "@/server/types/db";
 import { getServerSession } from "../auth/session";
 import type { PaginationParams } from "@/types";
-
-export type PaginatedLikes = {
-  items: DbLike[];
-  metadata: {
-    currentPage: number;
-    totalPages: number;
-    totalItems: number;
-    hasNextPage: boolean;
-  };
-};
+import { PaginatedResponse } from "../types/profile";
 
 export const likes = {
   queries: {
@@ -36,7 +27,7 @@ export const likes = {
     getAllByUserId: async (
       userId: DbUser["id"],
       { page = 1, limit = 10 }: PaginationParams,
-    ): Promise<PaginatedLikes> => {
+    ): Promise<PaginatedResponse<DbLike>> => {
       return unstable_cache(
         async () => {
           const offset = (page - 1) * limit;
@@ -110,7 +101,7 @@ export const likes = {
     getPaginatedLikes: async (
       userId: DbUser["id"],
       { page = 1, limit = 10 }: PaginationParams,
-    ): Promise<PaginatedLikes> => {
+    ): Promise<PaginatedResponse<DbLike>> => {
       const userLikes = await likes.queries.getAllByUserId(userId, {
         page,
         limit,

--- a/src/server/data/lists.ts
+++ b/src/server/data/lists.ts
@@ -31,7 +31,7 @@ export const lists = {
 
     getAllByUserId: async (
       userId: DbUser["id"],
-      isOwnProfile: boolean,
+      isOwner: boolean,
       { page = 1, limit = 10 }: PaginationParams = {},
     ) => {
       return unstable_cache(
@@ -46,14 +46,14 @@ export const lists = {
             .where(
               and(
                 eq(list.userId, userId),
-                isOwnProfile ? undefined : eq(list.isPublic, true),
+                isOwner ? undefined : eq(list.isPublic, true),
               ),
             );
 
           const items = await db.query.list.findMany({
             where: and(
               eq(list.userId, userId),
-              isOwnProfile ? undefined : eq(list.isPublic, true),
+              isOwner ? undefined : eq(list.isPublic, true),
             ),
             orderBy: (list, { desc }) => [desc(list.createdAt)],
             limit,
@@ -84,7 +84,7 @@ export const lists = {
             },
           };
         },
-        [`user-${userId}-lists-page-${page}-auth-${isOwnProfile}`],
+        [`user-${userId}-lists-page-${page}-auth-${isOwner}`],
         {
           tags: [`user-${userId}-lists`, `user-lists`],
           revalidate: 60,
@@ -94,7 +94,7 @@ export const lists = {
 
     getAllByUsername: async (
       username: string,
-      isOwnProfile: boolean,
+      isOwner: boolean,
       { page = 1, limit = 10 }: PaginationParams = {},
     ) => {
       return unstable_cache(
@@ -102,12 +102,12 @@ export const lists = {
           const user = await users.queries.getByUsername(username);
           if (!user) return null;
 
-          return lists.queries.getAllByUserId(user.id, isOwnProfile, {
+          return lists.queries.getAllByUserId(user.id, isOwner, {
             page,
             limit,
           });
         },
-        [`user-${username}-lists-page-${page}-auth-${isOwnProfile}`],
+        [`user-${username}-lists-page-${page}-auth-${isOwner}`],
         {
           tags: [`user-${username}-lists`, `user-lists`],
           revalidate: 60,

--- a/src/server/data/users.ts
+++ b/src/server/data/users.ts
@@ -5,34 +5,6 @@ import type { DbUser } from "@/server/types/db";
 import { db } from "@/server/db";
 import { user, like, list } from "@/server/db/schema";
 import { getServerSession } from "@/server/auth/session";
-// import { getEnhancedPlacePhoto } from "@/server/services/photos";
-// import type { Place } from "@/types";
-
-// const FIELD_MASK = [
-//   "id",
-//   "displayName",
-//   "formattedAddress",
-//   "photos",
-//   "rating",
-//   "userRatingCount",
-//   "priceLevel",
-// ].join(",");
-
-// const processPlacePhotos = async (place: Place): Promise<Place> => {
-//   try {
-//     if (!place.photos?.[0]) {
-//       return place;
-//     }
-
-//     return {
-//       ...place,
-//       image: await getEnhancedPlacePhoto(place.photos[0].name),
-//     };
-//   } catch (error) {
-//     console.warn(`Failed to process photo for place ${place.id}:`, error);
-//     return place;
-//   }
-// };
 
 export const users = {
   queries: {

--- a/src/server/data/users.ts
+++ b/src/server/data/users.ts
@@ -3,45 +3,36 @@
 import { eq, sql } from "drizzle-orm";
 import type { DbUser } from "@/server/types/db";
 import { db } from "@/server/db";
-import { user, like } from "@/server/db/schema";
+import { user, like, list } from "@/server/db/schema";
 import { getServerSession } from "@/server/auth/session";
-import type {
-  PublicProfileData,
-  PrivateProfileData,
-} from "@/server/types/profile";
-import { profileParamsSchema } from "@/lib/validations/profile";
-import { ProfileParams } from "@/lib/validations/profile";
-import { lists } from "@/server/data/lists";
-import { likes } from "@/server/data/likes";
-import { env } from "@/env";
-import { getEnhancedPlacePhoto } from "@/server/services/photos";
-import type { Place } from "@/types";
+// import { getEnhancedPlacePhoto } from "@/server/services/photos";
+// import type { Place } from "@/types";
 
-const FIELD_MASK = [
-  "id",
-  "displayName",
-  "formattedAddress",
-  "photos",
-  "rating",
-  "userRatingCount",
-  "priceLevel",
-].join(",");
+// const FIELD_MASK = [
+//   "id",
+//   "displayName",
+//   "formattedAddress",
+//   "photos",
+//   "rating",
+//   "userRatingCount",
+//   "priceLevel",
+// ].join(",");
 
-const processPlacePhotos = async (place: Place): Promise<Place> => {
-  try {
-    if (!place.photos?.[0]) {
-      return place;
-    }
+// const processPlacePhotos = async (place: Place): Promise<Place> => {
+//   try {
+//     if (!place.photos?.[0]) {
+//       return place;
+//     }
 
-    return {
-      ...place,
-      image: await getEnhancedPlacePhoto(place.photos[0].name),
-    };
-  } catch (error) {
-    console.warn(`Failed to process photo for place ${place.id}:`, error);
-    return place;
-  }
-};
+//     return {
+//       ...place,
+//       image: await getEnhancedPlacePhoto(place.photos[0].name),
+//     };
+//   } catch (error) {
+//     console.warn(`Failed to process photo for place ${place.id}:`, error);
+//     return place;
+//   }
+// };
 
 export const users = {
   queries: {
@@ -70,110 +61,35 @@ export const users = {
         },
       });
 
-      if (!foundUser) return null;
+      if (!foundUser) {
+        return null;
+      }
 
       const session = await getServerSession();
-      const isOwnProfile = session?.user.id === foundUser.id;
+      const isOwner = session?.user.id === foundUser.id;
 
       return {
         name: foundUser.name,
         username: foundUser.username,
         isPublic: foundUser.isPublic,
-        isOwnProfile,
+        isOwner,
       };
     },
 
-    getProfile: async (
-      params: ProfileParams,
-    ): Promise<PublicProfileData | PrivateProfileData | null> => {
-      const validated = profileParamsSchema.safeParse(params);
-      if (!validated.success) {
-        throw new Error("Invalid profile parameters");
-      }
-
-      const { username, page, limit } = validated.data;
-
-      const foundUser = await db.query.user.findFirst({
-        where: eq(user.username, username),
-      });
-
-      if (!foundUser) return null;
-
-      const session = await getServerSession();
-      const isOwnProfile = session?.user.id === foundUser.id;
-
-      if (!isOwnProfile && !foundUser.isPublic) {
-        return {
-          type: "private",
-          username: foundUser.username,
-        };
-      }
-
-      const [userLists, userLikes, likesCount] = await Promise.all([
-        lists.queries.getAllByUserId(foundUser.id, isOwnProfile, {
-          page,
-          limit,
-        }),
-        likes.queries.getAllByUserId(foundUser.id, {
-          page,
-          limit,
-        }),
+    getListsAndLikesCount: async (userId: string) => {
+      const [listsCount, likesCount] = await Promise.all([
+        db
+          .select({ count: sql<number>`count(*)` })
+          .from(list)
+          .where(eq(list.userId, userId))
+          .then((result) => Number(result[0].count)),
         db
           .select({ count: sql<number>`count(*)` })
           .from(like)
-          .where(eq(like.userId, foundUser.id))
+          .where(eq(like.userId, userId))
           .then((result) => Number(result[0].count)),
       ]);
-
-      // Fetch place details for each like
-      const likesWithPlaceDetails = await Promise.all(
-        userLikes.items.map(async (like) => {
-          const res = await fetch(
-            `${env.GOOGLE_PLACES_API_BASE_URL}/places/${like.placeId}`,
-            {
-              headers: {
-                "X-Goog-Api-Key": env.GOOGLE_PLACES_API_KEY,
-                "X-Goog-FieldMask": FIELD_MASK,
-              },
-              next: {
-                revalidate: 3600, // Cache for 1 hour
-              },
-            },
-          );
-
-          if (!res.ok) {
-            console.error(
-              `Failed to fetch place details for ${like.placeId}:`,
-              await res.text(),
-            );
-            return null;
-          }
-
-          const placeDetails = await res.json();
-          const processedPlace = await processPlacePhotos(placeDetails);
-
-          return {
-            placeId: like.placeId,
-            place: processedPlace,
-          };
-        }),
-      );
-
-      // Filter out any failed requests
-      const validLikes = likesWithPlaceDetails.filter(
-        (like): like is NonNullable<typeof like> => like !== null,
-      );
-
-      return {
-        user: { ...foundUser, type: "public" as const },
-        isOwnProfile,
-        lists: userLists,
-        likes: {
-          items: validLikes,
-          metadata: userLikes.metadata,
-        },
-        totalLikes: likesCount,
-      };
+      return { listsCount, likesCount };
     },
 
     getPlaceData: async (userId: string) => {

--- a/src/server/services/likes.ts
+++ b/src/server/services/likes.ts
@@ -1,0 +1,50 @@
+import { LIKES_FIELD_MASK } from "@/constants/likes";
+import { processPlaceThumbnail } from "./photos";
+import { env } from "@/env";
+import { likes } from "@/server/data/likes";
+
+export const getLikesWithPlaceDetails = async (userId: string) => {
+  const userLikes = await likes.queries.getAllByUserId(userId, {
+    page: 1,
+    limit: 10,
+  });
+
+  const likesWithPlaceDetails = await Promise.all(
+    userLikes.items.map(async (like) => {
+      const res = await fetch(
+        `${env.GOOGLE_PLACES_API_BASE_URL}/places/${like.placeId}`,
+        {
+          headers: {
+            "X-Goog-Api-Key": env.GOOGLE_PLACES_API_KEY,
+            "X-Goog-FieldMask": LIKES_FIELD_MASK,
+          },
+          next: {
+            revalidate: 3600,
+          },
+        },
+      );
+
+      if (!res.ok) {
+        console.error(
+          `Failed to fetch place details for ${like.placeId}:`,
+          await res.text(),
+        );
+        return null;
+      }
+
+      const placeDetails = await res.json();
+      const processedPlace = await processPlaceThumbnail(placeDetails);
+
+      return {
+        placeId: like.placeId,
+        place: processedPlace,
+      };
+    }),
+  );
+
+  const validLikesWithDetails = likesWithPlaceDetails.filter(
+    (like): like is NonNullable<typeof like> => like !== null,
+  );
+
+  return validLikesWithDetails;
+};

--- a/src/server/services/photos.ts
+++ b/src/server/services/photos.ts
@@ -4,6 +4,7 @@ import { cache } from "react";
 import { env } from "@/env";
 import { getPlacePhotoUrl } from "@/lib/place";
 import { getPlaiceholder } from "plaiceholder";
+import { Place } from "@/types";
 
 export const getEnhancedPlacePhoto = cache(async (photoRef: string) => {
   try {
@@ -33,3 +34,19 @@ export const getEnhancedPlacePhoto = cache(async (photoRef: string) => {
     throw error;
   }
 });
+
+export const processPlaceThumbnail = async (place: Place): Promise<Place> => {
+  try {
+    if (!place.photos?.[0]) {
+      return place;
+    }
+
+    return {
+      ...place,
+      image: await getEnhancedPlacePhoto(place.photos[0].name),
+    };
+  } catch (error) {
+    console.warn(`Failed to process photo for place ${place.id}:`, error);
+    return place;
+  }
+};

--- a/src/server/services/profile.ts
+++ b/src/server/services/profile.ts
@@ -24,9 +24,9 @@ export const getUser = cache(
     if (!user) return null;
 
     const session = await getServerSession();
-    const isOwnProfile = session?.user.id === user.id;
+    const isOwner = session?.user.id === user.id;
 
-    if (!isOwnProfile && !user.isPublic) {
+    if (!isOwner && !user.isPublic) {
       return {
         username: user.username,
         type: "private",

--- a/src/server/types/profile.ts
+++ b/src/server/types/profile.ts
@@ -1,16 +1,15 @@
 import type { DbUser } from "@/server/types/db";
-// import type { lists } from "@/server/data/lists";
 import type { Place } from "@/types";
 
-// interface PaginatedResponse<T> {
-//   items: T[];
-//   metadata: {
-//     currentPage: number;
-//     totalPages: number;
-//     totalItems: number;
-//     hasNextPage: boolean;
-//   };
-// }
+export interface PaginatedResponse<T> {
+  items: T[];
+  metadata: {
+    currentPage: number;
+    totalPages: number;
+    totalItems: number;
+    hasNextPage: boolean;
+  };
+}
 
 export interface LikeItem {
   placeId: string;

--- a/src/server/types/profile.ts
+++ b/src/server/types/profile.ts
@@ -1,33 +1,25 @@
 import type { DbUser } from "@/server/types/db";
-import type { lists } from "@/server/data/lists";
+// import type { lists } from "@/server/data/lists";
 import type { Place } from "@/types";
 
-interface PaginatedResponse<T> {
-  items: T[];
-  metadata: {
-    currentPage: number;
-    totalPages: number;
-    totalItems: number;
-    hasNextPage: boolean;
-  };
-}
+// interface PaginatedResponse<T> {
+//   items: T[];
+//   metadata: {
+//     currentPage: number;
+//     totalPages: number;
+//     totalItems: number;
+//     hasNextPage: boolean;
+//   };
+// }
 
-interface LikeItem {
+export interface LikeItem {
   placeId: string;
   place: Place;
 }
 
-export type PublicProfileData = {
-  user: DbUser & { type: "public" };
-  lists: Awaited<ReturnType<typeof lists.queries.getAllByUserId>>;
-  likes: PaginatedResponse<LikeItem>;
-  isOwnProfile: boolean;
+export type ProfileData = {
+  user: DbUser;
+  isOwner: boolean;
   totalLikes: number;
+  totalLists: number;
 };
-
-export type PrivateProfileData = {
-  username: string;
-  type: "private";
-};
-
-export type ProfileData = PublicProfileData | PrivateProfileData;

--- a/src/server/utils/profile.ts
+++ b/src/server/utils/profile.ts
@@ -5,10 +5,10 @@ import { getServerSession } from "@/server/auth/session";
 
 export const canViewProfile = async (profileUser: DbUser) => {
   const session = await getServerSession();
-  const isOwnProfile = session?.user.id === profileUser.id;
+  const isOwner = session?.user.id === profileUser.id;
 
   return {
-    canView: isOwnProfile || profileUser.isPublic,
-    isOwnProfile,
+    canView: isOwner || profileUser.isPublic,
+    isOwner,
   };
 };


### PR DESCRIPTION
- Replaced `isOwnProfile` with `isOwner` in every file.
- Introduced `ProfileLikesTab` and `ProfileListsTab` components to handle likes and lists separately.
- Adjusted and optimized profile fetching logic.
- Updated the validation schema for profile, likes and lists.
