### PR TITLE
fix: optimize location handling across search and category components

### DIFF
--- a/src/app/(root)/discover/page.tsx
+++ b/src/app/(root)/discover/page.tsx
@@ -1,4 +1,3 @@
-import { LocationProvider } from "@/contexts/LocationContext";
 import { createMetadata } from "@/lib/metadata";
 import { DiscoverContent } from "@/components/discover/DiscoverContent";
 
@@ -10,18 +9,16 @@ export const metadata = createMetadata({
 
 const DiscoverPage = () => {
   return (
-    <LocationProvider>
-      <div className="container mx-auto px-4 py-6 sm:py-8 md:py-10">
-        <h1 className="text-3xl font-bold tracking-tighter md:text-4xl">
-          Discover
-        </h1>
-        <p className="mb-8 mt-2 text-muted-foreground">
-          Search near you or anywhere in the world.
-        </p>
+    <div className="container mx-auto px-4 py-6 sm:py-8 md:py-10">
+      <h1 className="text-3xl font-bold tracking-tighter md:text-4xl">
+        Discover
+      </h1>
+      <p className="mb-8 mt-2 text-muted-foreground">
+        Search near you or anywhere in the world.
+      </p>
 
-        <DiscoverContent />
-      </div>
-    </LocationProvider>
+      <DiscoverContent />
+    </div>
   );
 };
 

--- a/src/app/(root)/layout.tsx
+++ b/src/app/(root)/layout.tsx
@@ -1,11 +1,14 @@
 import { Nav, Footer } from "@/components/layout";
+import { LocationProvider } from "@/contexts";
 
 const AppLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
-      <Nav />
-      <main>{children}</main>
-      <Footer />
+      <LocationProvider>
+        <Nav />
+        <main>{children}</main>
+        <Footer />
+      </LocationProvider>
     </>
   );
 };

--- a/src/components/home/CategoryCarousel/CategoryCarousels.tsx
+++ b/src/components/home/CategoryCarousel/CategoryCarousels.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { HOME_CATEGORIES } from "@/constants";
-import { LocationProvider } from "@/contexts";
 import { CategoryCarousel } from "./";
 
 export const CategoryCarousels = () => {
@@ -15,18 +14,16 @@ export const CategoryCarousels = () => {
           Browse popular categories to jumpstart your exploration
         </p>
       </div>
-      <LocationProvider>
-        {HOME_CATEGORIES.map(({ title, query, icon }) => {
-          return (
-            <CategoryCarousel
-              key={title}
-              title={title}
-              query={query}
-              icon={icon}
-            />
-          );
-        })}
-      </LocationProvider>
+      {HOME_CATEGORIES.map(({ title, query, icon }) => {
+        return (
+          <CategoryCarousel
+            key={title}
+            title={title}
+            query={query}
+            icon={icon}
+          />
+        );
+      })}
     </section>
   );
 };

--- a/src/hooks/categories/useCategoryList.ts
+++ b/src/hooks/categories/useCategoryList.ts
@@ -2,6 +2,7 @@ import { useQueries } from "@tanstack/react-query";
 import { HOME_CATEGORIES, QUERY_KEYS } from "@/constants";
 import { searchPlacesClient } from "@/lib/search";
 import { useLocation } from "@/contexts/LocationContext";
+import { useMemo } from "react";
 import type { PlaceSearchResponse } from "@/types";
 
 interface UseCategoryListResponse {
@@ -17,24 +18,61 @@ export const useCategoryList = (): UseCategoryListResponse[] => {
     coords,
     isLoading: isLoadingLocation,
     permissionState,
+    isPermissionPending,
   } = useLocation();
 
-  const useLocationBias =
-    !isLoadingLocation &&
-    permissionState === "granted" &&
-    coords.latitude !== null &&
-    coords.longitude !== null;
+  const useLocationBias = useMemo(() => {
+    const result =
+      permissionState === "granted" &&
+      !isLoadingLocation &&
+      !isPermissionPending &&
+      coords.latitude !== null &&
+      coords.longitude !== null;
+
+    return result;
+  }, [coords, isLoadingLocation, permissionState, isPermissionPending]);
+
+  const shouldEnableQueries = useMemo(() => {
+    // If location permission is still pending, don't query yet
+    if (isPermissionPending) return false;
+
+    // If permission granted but location still loading, don't query yet
+    if (permissionState === "granted" && isLoadingLocation) return false;
+
+    // If permission denied/unavailable/timeout, we can search without location
+    if (["denied", "unavailable", "timeout"].includes(permissionState))
+      return true;
+
+    // If permission granted and we have location data, we can search
+    if (
+      permissionState === "granted" &&
+      !isLoadingLocation &&
+      coords.latitude !== null &&
+      coords.longitude !== null
+    )
+      return true;
+
+    return false;
+  }, [permissionState, isLoadingLocation, coords, isPermissionPending]);
 
   const queries = useQueries({
-    queries: HOME_CATEGORIES.map(({ query }) => ({
+    queries: HOME_CATEGORIES.map(({ query, title }) => ({
       queryKey: [QUERY_KEYS.CATEGORIES, query, useLocationBias ? coords : null],
-      queryFn: () =>
-        searchPlacesClient(
-          query,
-          6,
-          useLocationBias ? coords : { latitude: null, longitude: null },
-        ),
-      enabled: !isLoadingLocation || permissionState !== "prompt",
+      queryFn: async () => {
+        try {
+          const result = await searchPlacesClient(
+            query,
+            6,
+            useLocationBias ? coords : { latitude: null, longitude: null },
+          );
+
+          return result;
+        } catch (error) {
+          console.error(`[CATEGORY_LIST] Error fetching "${title}":`, error);
+          throw error;
+        }
+      },
+      enabled: shouldEnableQueries,
     })),
   });
 

--- a/src/hooks/categories/useCategoryPlaces.ts
+++ b/src/hooks/categories/useCategoryPlaces.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { searchPlacesClient } from "@/lib/search";
 import { useLocation } from "@/contexts/LocationContext";
 import { QUERY_KEYS } from "@/constants";
+import { useMemo } from "react";
 
 interface UseCategoryPlacesOptions {
   query: string;
@@ -16,22 +17,67 @@ export const useCategoryPlaces = ({
     coords,
     isLoading: isLoadingLocation,
     permissionState,
+    isPermissionPending,
   } = useLocation();
 
-  const useLocationBias =
-    !isLoadingLocation &&
-    permissionState === "granted" &&
-    coords.latitude !== null &&
-    coords.longitude !== null;
+  const useLocationBias = useMemo(() => {
+    const result =
+      permissionState === "granted" &&
+      !isLoadingLocation &&
+      !isPermissionPending &&
+      coords.latitude !== null &&
+      coords.longitude !== null;
+
+    return result;
+  }, [coords, isLoadingLocation, permissionState, isPermissionPending]);
+
+  const shouldEnableQuery = useMemo(() => {
+    if (!enabled) return false;
+
+    // If location permission is still pending, don't query yet
+    if (isPermissionPending) return false;
+
+    // If permission granted but location still loading, don't query yet
+    if (permissionState === "granted" && isLoadingLocation) return false;
+
+    // If permission denied/unavailable/timeout, we can search without location
+    if (["denied", "unavailable", "timeout"].includes(permissionState))
+      return true;
+
+    // If permission granted and we have location data, we can search
+    if (
+      permissionState === "granted" &&
+      !isLoadingLocation &&
+      coords.latitude !== null &&
+      coords.longitude !== null
+    )
+      return true;
+
+    return false;
+  }, [
+    enabled,
+    permissionState,
+    isLoadingLocation,
+    coords,
+    isPermissionPending,
+  ]);
 
   return useQuery({
     queryKey: [QUERY_KEYS.CATEGORIES, query, useLocationBias ? coords : null],
-    queryFn: () =>
-      searchPlacesClient(
-        query,
-        6,
-        useLocationBias ? coords : { latitude: null, longitude: null },
-      ),
-    enabled: enabled && (!isLoadingLocation || permissionState !== "prompt"),
+    queryFn: async () => {
+      try {
+        const result = await searchPlacesClient(
+          query,
+          6,
+          useLocationBias ? coords : { latitude: null, longitude: null },
+        );
+
+        return result;
+      } catch (error) {
+        console.error(`[CATEGORY] Error fetching "${query}":`, error);
+        throw error;
+      }
+    },
+    enabled: shouldEnableQuery,
   });
 };

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -79,20 +79,33 @@ export async function searchPlacesClient(
   pageToken?: string | null,
 ): Promise<PlaceSearchResponse | null> {
   try {
-    const searchParams = new URLSearchParams({
+    const params: Record<string, string> = {
       q: query,
-      minRating: filters?.minRating?.toString() || "",
-      openNow: filters?.openNow?.toString() || "",
-      radius: filters?.radius?.toString() || "",
       size: size.toString(),
-      lat: coords.latitude?.toString() || "",
-      lng: coords.longitude?.toString() || "",
-    });
+    };
 
-    if (pageToken) {
-      searchParams.set("pageToken", pageToken);
+    if (filters?.minRating) {
+      params.minRating = filters.minRating.toString();
     }
 
+    if (filters?.openNow !== undefined) {
+      params.openNow = filters.openNow.toString();
+    }
+
+    if (filters?.radius) {
+      params.radius = filters.radius.toString();
+    }
+
+    if (coords.latitude !== null && coords.longitude !== null) {
+      params.lat = coords.latitude.toString();
+      params.lng = coords.longitude.toString();
+    }
+
+    if (pageToken) {
+      params.pageToken = pageToken;
+    }
+
+    const searchParams = new URLSearchParams(params);
     const url = `/api/places/search?${searchParams.toString()}`;
 
     const res = await fetch(url);


### PR DESCRIPTION
This PR improves location handling across the app to prevent double fetches and ensure consistent behavior when location permission is requested.

- Added `isPermissionPending` flag to `LocationContext` to properly track when we're waiting for permission response
- Optimized `useLocationBias` logic in `useSearch`, `useCategoryPlaces`, and `useCategoryList` hooks
- Implemented consistent `shouldEnableSearch`/`shouldEnableQuery` conditions across all data fetching hooks
- Increased location timeout from 5s to 10s for better reliability
