### PR TITLE
feat: implement place type tracking based on user interactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-hook-form": "^7.54.2",
     "react-intersection-observer": "^9.16.0",
     "resend": "^4.1.2",
+    "server-only": "^0.0.1",
     "sharp": "^0.33.5",
     "slugify": "^1.6.6",
     "sonner": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       resend:
         specifier: ^4.1.2
         version: 4.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       sharp:
         specifier: ^0.33.5
         version: 0.33.5
@@ -3297,6 +3300,9 @@ packages:
     resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
@@ -6639,6 +6645,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.1: {}
+
+  server-only@0.0.1: {}
 
   set-cookie-parser@2.7.1: {}
 

--- a/src/lib/api/places.ts
+++ b/src/lib/api/places.ts
@@ -73,3 +73,35 @@ export const getPlaceDetails = cache(
     return res.json();
   },
 );
+
+interface PlaceTypesResponse {
+  id: string;
+  primaryType?: string;
+  types?: string[];
+}
+
+export async function getPlaceTypes(
+  placeId: string,
+): Promise<PlaceTypesResponse | null> {
+  try {
+    const response = await fetch(
+      `${env.GOOGLE_PLACES_API_BASE_URL}/places/${placeId}`,
+      {
+        headers: {
+          "X-Goog-Api-Key": env.GOOGLE_PLACES_API_KEY,
+          "X-Goog-FieldMask": "id,primaryType,types",
+        },
+      },
+    );
+
+    if (!response.ok) {
+      console.error(`Error fetching place types: ${response.status}`);
+      return null;
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error("Failed to fetch place types:", error);
+    return null;
+  }
+}

--- a/src/lib/plaiceholder.ts
+++ b/src/lib/plaiceholder.ts
@@ -1,4 +1,4 @@
-"server-only";
+import "server-only";
 
 import { getPlaiceholder } from "plaiceholder";
 

--- a/src/server/actions/like.ts
+++ b/src/server/actions/like.ts
@@ -4,6 +4,8 @@ import { revalidateTag } from "next/cache";
 import { getServerSession } from "../auth/session";
 import { likes } from "@/server/data/likes";
 import { withActionLimit } from "../lib/rate-limit";
+import { userTypePreferences } from "@/server/data/userTypePreferences";
+import { getPlaceTypes } from "@/lib/api/places";
 
 export const toggleLike = withActionLimit(async (placeId: string) => {
   const session = await getServerSession();
@@ -14,6 +16,22 @@ export const toggleLike = withActionLimit(async (placeId: string) => {
   revalidateTag("user-likes");
   revalidateTag(`like-${session.user.id}-${placeId}`);
   revalidateTag(`user-${session.user.id}-likes-statuses`);
+
+  if (result.liked === true) {
+    try {
+      const placeTypes = await getPlaceTypes(placeId);
+
+      if (placeTypes) {
+        await userTypePreferences.mutations.trackPlaceTypes(
+          session.user.id,
+          placeTypes.primaryType || null,
+          placeTypes.types || [],
+        );
+      }
+    } catch (error) {
+      console.error("Failed to update type preferences:", error);
+    }
+  }
 
   return result;
 }, "likes");

--- a/src/server/actions/savedPlace.ts
+++ b/src/server/actions/savedPlace.ts
@@ -35,12 +35,10 @@ export const updateSavedPlaces = withActionLimit(
       );
       const newListIds = new Set(selectedLists);
 
-      let wasRemoved = false;
       for (const list of currentLists) {
         if (currentListIds.has(list.id) && !newListIds.has(list.id)) {
           await savedPlaces.mutations.delete(list.id, placeId);
           revalidateTag(`list-${list.id}-places`);
-          wasRemoved = true;
         }
       }
 

--- a/src/server/actions/savedPlace.ts
+++ b/src/server/actions/savedPlace.ts
@@ -6,6 +6,8 @@ import { getServerSession } from "../auth/session";
 import { revalidateTag } from "next/cache";
 import { z } from "zod";
 import { withActionLimit } from "@/server/lib/rate-limit";
+import { userTypePreferences } from "@/server/data/userTypePreferences";
+import { getPlaceTypes } from "@/lib/api/places";
 
 const updateSavedPlacesSchema = z.object({
   placeId: z.string(),
@@ -33,23 +35,43 @@ export const updateSavedPlaces = withActionLimit(
       );
       const newListIds = new Set(selectedLists);
 
+      let wasRemoved = false;
       for (const list of currentLists) {
         if (currentListIds.has(list.id) && !newListIds.has(list.id)) {
           await savedPlaces.mutations.delete(list.id, placeId);
           revalidateTag(`list-${list.id}-places`);
+          wasRemoved = true;
         }
       }
 
+      let wasAdded = false;
       for (const listId of newListIds) {
         if (!currentListIds.has(listId)) {
           await savedPlaces.mutations.create({ listId, placeId });
           revalidateTag(`list-${listId}-places`);
+          wasAdded = true;
         }
       }
 
       revalidateTag(`user-${session.user.id}-lists`);
       revalidateTag("user-lists");
       revalidateTag("list-places");
+
+      if (wasAdded) {
+        try {
+          const placeTypes = await getPlaceTypes(placeId);
+
+          if (placeTypes) {
+            await userTypePreferences.mutations.trackPlaceTypes(
+              session.user.id,
+              placeTypes.primaryType || null,
+              placeTypes.types || [],
+            );
+          }
+        } catch (error) {
+          console.error("Failed to update type preferences:", error);
+        }
+      }
 
       return { success: true };
     } catch (error) {

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -1,4 +1,4 @@
-"server-only";
+import "server-only";
 
 import { auth } from "@/server/auth/auth";
 import { headers } from "next/headers";

--- a/src/server/data/likes.ts
+++ b/src/server/data/likes.ts
@@ -127,12 +127,12 @@ export const likes = {
       });
 
       if (existing) {
-        return {
-          liked: !!(await db.delete(like).where(eq(like.id, existing.id))),
-        };
+        await db.delete(like).where(eq(like.id, existing.id));
+        return { liked: false };
       }
 
-      return { liked: !!(await db.insert(like).values({ userId, placeId })) };
+      await db.insert(like).values({ userId, placeId });
+      return { liked: true };
     },
   },
 } as const;

--- a/src/server/data/userTypePreferences.ts
+++ b/src/server/data/userTypePreferences.ts
@@ -1,0 +1,98 @@
+import "server-only";
+
+import { and, eq, desc } from "drizzle-orm";
+import { db } from "@/server/db";
+import {
+  userPrimaryTypePreference,
+  userTypePreference,
+} from "@/server/db/schema";
+import type { DbUser } from "@/server/types/db";
+
+export const userTypePreferences = {
+  queries: {
+    async getUserTypePreferences(userId: DbUser["id"]) {
+      return {
+        primaryTypes: await db.query.userPrimaryTypePreference.findMany({
+          where: eq(userPrimaryTypePreference.userId, userId),
+          orderBy: [desc(userPrimaryTypePreference.count)],
+        }),
+        allTypes: await db.query.userTypePreference.findMany({
+          where: eq(userTypePreference.userId, userId),
+          orderBy: [desc(userTypePreference.count)],
+        }),
+      };
+    },
+  },
+
+  mutations: {
+    async updatePrimaryTypePreference(userId: DbUser["id"], placeType: string) {
+      const existing = await db.query.userPrimaryTypePreference.findFirst({
+        where: and(
+          eq(userPrimaryTypePreference.userId, userId),
+          eq(userPrimaryTypePreference.placeType, placeType),
+        ),
+      });
+
+      if (existing) {
+        return db
+          .update(userPrimaryTypePreference)
+          .set({ count: existing.count + 1 })
+          .where(
+            and(
+              eq(userPrimaryTypePreference.userId, userId),
+              eq(userPrimaryTypePreference.placeType, placeType),
+            ),
+          );
+      } else {
+        return db.insert(userPrimaryTypePreference).values({
+          userId,
+          placeType,
+          count: 1,
+        });
+      }
+    },
+
+    async updateTypePreference(userId: DbUser["id"], placeType: string) {
+      const existing = await db.query.userTypePreference.findFirst({
+        where: and(
+          eq(userTypePreference.userId, userId),
+          eq(userTypePreference.placeType, placeType),
+        ),
+      });
+
+      if (existing) {
+        return db
+          .update(userTypePreference)
+          .set({ count: existing.count + 1 })
+          .where(
+            and(
+              eq(userTypePreference.userId, userId),
+              eq(userTypePreference.placeType, placeType),
+            ),
+          );
+      } else {
+        return db.insert(userTypePreference).values({
+          userId,
+          placeType,
+          count: 1,
+        });
+      }
+    },
+
+    async trackPlaceTypes(
+      userId: DbUser["id"],
+      primaryType: string | null,
+      types: string[],
+    ) {
+      if (primaryType) {
+        await this.updatePrimaryTypePreference(userId, primaryType);
+      }
+
+      if (types && types.length > 0) {
+        await Promise.all(
+          types.map((type) => this.updateTypePreference(userId, type)),
+        );
+      }
+    },
+  },
+} as const;

--- a/src/server/data/users.ts
+++ b/src/server/data/users.ts
@@ -1,4 +1,4 @@
-"server-only";
+import "server-only";
 
 import { eq, sql } from "drizzle-orm";
 import type { DbUser } from "@/server/types/db";

--- a/src/server/db/migrations/0006_tranquil_layla_miller.sql
+++ b/src/server/db/migrations/0006_tranquil_layla_miller.sql
@@ -1,0 +1,26 @@
+CREATE TABLE "user_primary_type_preference" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"place_type" text NOT NULL,
+	"count" integer DEFAULT 1 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_primary_type_preference_id_unique" UNIQUE("id")
+);
+--> statement-breakpoint
+CREATE TABLE "user_type_preference" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"place_type" text NOT NULL,
+	"count" integer DEFAULT 1 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_type_preference_id_unique" UNIQUE("id")
+);
+--> statement-breakpoint
+ALTER TABLE "user_primary_type_preference" ADD CONSTRAINT "user_primary_type_preference_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_type_preference" ADD CONSTRAINT "user_type_preference_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "primary_type_user_idx" ON "user_primary_type_preference" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "primary_type_user_place_type_idx" ON "user_primary_type_preference" USING btree ("user_id","place_type");--> statement-breakpoint
+CREATE INDEX "type_user_idx" ON "user_type_preference" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "type_user_place_type_idx" ON "user_type_preference" USING btree ("user_id","place_type");

--- a/src/server/db/migrations/meta/0006_snapshot.json
+++ b/src/server/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1054 @@
+{
+  "id": "4b7dc7ae-2500-42af-bc18-07a98cd766f1",
+  "prevId": "ebd20f76-2edf-4bd7-9e2c-750b9672115e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_id_unique": {
+          "name": "account_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_id_unique": {
+          "name": "session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "username_updated_at": {
+          "name": "username_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "colour": {
+          "name": "colour",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'oklch(0.7 0.24 270)'"
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_id_unique": {
+          "name": "user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "verification_id_unique": {
+          "name": "verification_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list": {
+      "name": "list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "colour": {
+          "name": "colour",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'oklch(0.7 0.24 270)'"
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "list_user_idx": {
+          "name": "list_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "list_user_id_user_id_fk": {
+          "name": "list_user_id_user_id_fk",
+          "tableFrom": "list",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "list_id_unique": {
+          "name": "list_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "list_user_slug_idx": {
+          "name": "list_user_slug_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_place": {
+      "name": "saved_place",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saved_place_list_place_idx": {
+          "name": "saved_place_list_place_idx",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "place_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_place_list_idx": {
+          "name": "saved_place_list_idx",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_place_list_id_list_id_fk": {
+          "name": "saved_place_list_id_list_id_fk",
+          "tableFrom": "saved_place",
+          "tableTo": "list",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "saved_place_id_unique": {
+          "name": "saved_place_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.like": {
+      "name": "like",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "like_user_place_idx": {
+          "name": "like_user_place_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "place_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "like_user_idx": {
+          "name": "like_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "like_user_id_user_id_fk": {
+          "name": "like_user_id_user_id_fk",
+          "tableFrom": "like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "like_id_unique": {
+          "name": "like_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.two_factor": {
+      "name": "two_factor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "two_factor_id_unique": {
+          "name": "two_factor_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_primary_type_preference": {
+      "name": "user_primary_type_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "place_type": {
+          "name": "place_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "primary_type_user_idx": {
+          "name": "primary_type_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "primary_type_user_place_type_idx": {
+          "name": "primary_type_user_place_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "place_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_primary_type_preference_user_id_user_id_fk": {
+          "name": "user_primary_type_preference_user_id_user_id_fk",
+          "tableFrom": "user_primary_type_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_primary_type_preference_id_unique": {
+          "name": "user_primary_type_preference_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_type_preference": {
+      "name": "user_type_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "place_type": {
+          "name": "place_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "type_user_idx": {
+          "name": "type_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "type_user_place_type_idx": {
+          "name": "type_user_place_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "place_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_type_preference_user_id_user_id_fk": {
+          "name": "user_type_preference_user_id_user_id_fk",
+          "tableFrom": "user_type_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_type_preference_id_unique": {
+          "name": "user_type_preference_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/server/db/migrations/meta/_journal.json
+++ b/src/server/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1742438764220,
       "tag": "0005_wandering_proemial_gods",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1742787221008,
+      "tag": "0006_tranquil_layla_miller",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/db/schema/index.ts
+++ b/src/server/db/schema/index.ts
@@ -5,3 +5,4 @@ export * from "./saved-place";
 export * from "./like";
 export * from "./relations";
 export * from "./twoFactor";
+export * from "./userTypePreferences";

--- a/src/server/db/schema/userTypePreferences.ts
+++ b/src/server/db/schema/userTypePreferences.ts
@@ -1,0 +1,41 @@
+import { text, uuid, integer, index, uniqueIndex } from "drizzle-orm/pg-core";
+import { pgTable } from "drizzle-orm/pg-core";
+import { timestamps, primaryKey } from "./common";
+import { user } from "./user";
+
+export const userPrimaryTypePreference = pgTable(
+  "user_primary_type_preference",
+  {
+    id: primaryKey(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    placeType: text("place_type").notNull(),
+    count: integer("count").notNull().default(1),
+    ...timestamps,
+  },
+  (table) => [
+    index("primary_type_user_idx").on(table.userId),
+    uniqueIndex("primary_type_user_place_type_idx").on(
+      table.userId,
+      table.placeType,
+    ),
+  ],
+);
+
+export const userTypePreference = pgTable(
+  "user_type_preference",
+  {
+    id: primaryKey(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    placeType: text("place_type").notNull(),
+    count: integer("count").notNull().default(1),
+    ...timestamps,
+  },
+  (table) => [
+    index("type_user_idx").on(table.userId),
+    uniqueIndex("type_user_place_type_idx").on(table.userId, table.placeType),
+  ],
+);

--- a/src/server/services/photos.ts
+++ b/src/server/services/photos.ts
@@ -1,4 +1,4 @@
-"server-only";
+import "server-only";
 
 import { cache } from "react";
 import { env } from "@/env";

--- a/src/server/services/places.ts
+++ b/src/server/services/places.ts
@@ -1,4 +1,4 @@
-"server-only";
+import "server-only";
 
 import { cache } from "react";
 import { env } from "@/env";

--- a/src/server/services/profile.ts
+++ b/src/server/services/profile.ts
@@ -1,4 +1,4 @@
-"server-only";
+import "server-only";
 
 import { cache } from "react";
 import { getServerSession } from "@/server/auth/session";

--- a/src/server/utils/profile.ts
+++ b/src/server/utils/profile.ts
@@ -1,4 +1,4 @@
-"server-only";
+import "server-only";
 
 import type { DbUser } from "@/server/types/db";
 import { getServerSession } from "@/server/auth/session";

--- a/src/server/utils/uploadThing.ts
+++ b/src/server/utils/uploadThing.ts
@@ -1,4 +1,4 @@
-"server-only";
+import "server-only";
 
 import { env } from "@/env";
 


### PR DESCRIPTION
This PR adds the ability to track user preferences for place types based on their interactions (likes and saves). This data will be used for personalization's in a future PR.

- Added database schema for user type preferences (primary types and all types)
- Created data access layer for type preferences tracking
- Implemented type tracking when users like places
- Implemented type tracking when users save places to lists
- Added utility to fetch place types from Google Places API